### PR TITLE
#11: 스터디 친구 요청 관리 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/edu/handong/csee/histudy/controller/UserController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/UserController.java
@@ -5,6 +5,7 @@ import edu.handong.csee.histudy.domain.Friendship;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.FriendshipDto;
 import edu.handong.csee.histudy.dto.FriendshipRequest;
+import edu.handong.csee.histudy.impl.ReceivedFriendshipRequest;
 import edu.handong.csee.histudy.impl.SentFriendshipRequest;
 import edu.handong.csee.histudy.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +33,33 @@ public class UserController {
                 .collect(Collectors.toList());
 
         return new FriendshipDto(sentRequests);
+    }
+
+    @PatchMapping("/me/friends/{sid}")
+    public FriendshipDto acceptFriendRequest(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
+                                             @PathVariable String sid) {
+        User user = userService.token2User(accessToken);
+        userService.acceptRequest(user, sid);
+
+        List<FriendshipRequest> receivedRequests = user.getReceivedRequests()
+                .stream()
+                .map(ReceivedFriendshipRequest::new)
+                .collect(Collectors.toList());
+
+        return new FriendshipDto(receivedRequests);
+    }
+
+    @DeleteMapping("/me/friends/{sid}")
+    public FriendshipDto declineFriendRequest(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
+                                              @PathVariable String sid) {
+        User user = userService.token2User(accessToken);
+        userService.declineRequest(user, sid);
+
+        List<FriendshipRequest> receivedRequests = user.getReceivedRequests()
+                .stream()
+                .map(ReceivedFriendshipRequest::new)
+                .collect(Collectors.toList());
+
+        return new FriendshipDto(receivedRequests);
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/controller/UserController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/UserController.java
@@ -1,0 +1,36 @@
+package edu.handong.csee.histudy.controller;
+
+import edu.handong.csee.histudy.controller.form.BuddyForm;
+import edu.handong.csee.histudy.domain.Friendship;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.dto.FriendshipDto;
+import edu.handong.csee.histudy.dto.FriendshipRequest;
+import edu.handong.csee.histudy.impl.SentFriendshipRequest;
+import edu.handong.csee.histudy.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/buddy")
+    public FriendshipDto sendFriendRequest(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
+                                           @RequestBody BuddyForm form) {
+
+        User sender = userService.token2User(accessToken);
+        List<Friendship> friendships = userService.sendRequest(sender, form);
+        List<FriendshipRequest> sentRequests = friendships.stream()
+                .map(SentFriendshipRequest::new)
+                .collect(Collectors.toList());
+
+        return new FriendshipDto(sentRequests);
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/controller/UserController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/UserController.java
@@ -15,13 +15,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/api/user")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/buddy")
+    @PostMapping("/me/friends")
     public FriendshipDto sendFriendRequest(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
                                            @RequestBody BuddyForm form) {
 

--- a/src/main/java/edu/handong/csee/histudy/controller/form/BuddyForm.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/form/BuddyForm.java
@@ -1,0 +1,22 @@
+package edu.handong.csee.histudy.controller.form;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BuddyForm {
+
+    /**
+     * Contains the ID of the student the user wants to study with.
+     */
+    private List<String> buddies;
+
+    public BuddyForm(String... buddies) {
+        this.buddies = Arrays.stream(buddies).toList();
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/domain/Friendship.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/Friendship.java
@@ -1,0 +1,31 @@
+package edu.handong.csee.histudy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Friendship {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User sent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User received;
+
+    @Enumerated(EnumType.STRING)
+    private FriendshipStatus status;
+
+    public Friendship(User sent, User received) {
+        this.sent = sent;
+        this.received = received;
+        this.status = FriendshipStatus.PENDING;
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/domain/Friendship.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/Friendship.java
@@ -28,4 +28,17 @@ public class Friendship {
         this.received = received;
         this.status = FriendshipStatus.PENDING;
     }
+
+    public void accept() {
+        if (this.status == FriendshipStatus.PENDING) {
+            this.status = FriendshipStatus.ACCEPTED;
+        }
+    }
+
+    public void decline() {
+        if (this.status == FriendshipStatus.PENDING) {
+            sent.getSentRequests().remove(this);
+            received.getReceivedRequests().remove(this);
+        }
+    }
 }

--- a/src/main/java/edu/handong/csee/histudy/domain/FriendshipStatus.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/FriendshipStatus.java
@@ -1,5 +1,5 @@
 package edu.handong.csee.histudy.domain;
 
 public enum FriendshipStatus {
-    NONE, PENDING, ACCEPTED, DECLINED
+    PENDING, ACCEPTED
 }

--- a/src/main/java/edu/handong/csee/histudy/domain/FriendshipStatus.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/FriendshipStatus.java
@@ -1,0 +1,5 @@
+package edu.handong.csee.histudy.domain;
+
+public enum FriendshipStatus {
+    NONE, PENDING, ACCEPTED, DECLINED
+}

--- a/src/main/java/edu/handong/csee/histudy/domain/User.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/User.java
@@ -6,11 +6,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
     @Id
@@ -36,6 +37,12 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Participates> participates;
 
+    @OneToMany(mappedBy = "sent", cascade = CascadeType.ALL)
+    private List<Friendship> sentRequests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "received", cascade = CascadeType.ALL)
+    private List<Friendship> receivedRequests = new ArrayList<>();
+
     @Builder
     public User(String id, String sid, String email, String name, String accessToken, Role role) {
         this.id = id;
@@ -49,5 +56,11 @@ public class User {
     public void belongTo(Team team) {
         this.team = team;
         team.getUsers().add(this);
+    }
+
+    public void add(User user) {
+        Friendship friendship = new Friendship(this, user);
+        this.sentRequests.add(friendship);
+        user.receivedRequests.add(friendship);
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/dto/FriendshipDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/FriendshipDto.java
@@ -1,0 +1,37 @@
+package edu.handong.csee.histudy.dto;
+
+import edu.handong.csee.histudy.domain.FriendshipStatus;
+import edu.handong.csee.histudy.domain.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FriendshipDto {
+    private List<Buddy> requests;
+
+    public FriendshipDto(List<FriendshipRequest> requests) {
+        this.requests = requests.stream()
+                .map(Buddy::new)
+                .toList();
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Buddy {
+        private String sid;
+        private String name;
+        private FriendshipStatus status;
+
+        public Buddy(FriendshipRequest request) {
+            User user = request.getUser();
+
+            this.sid = user.getSid();
+            this.name = user.getName();
+            this.status = request.getStatus();
+        }
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/dto/FriendshipRequest.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/FriendshipRequest.java
@@ -1,0 +1,13 @@
+package edu.handong.csee.histudy.dto;
+
+import edu.handong.csee.histudy.domain.FriendshipStatus;
+import edu.handong.csee.histudy.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public abstract class FriendshipRequest {
+    private final User user;
+    private final FriendshipStatus status;
+}

--- a/src/main/java/edu/handong/csee/histudy/impl/ReceivedFriendshipRequest.java
+++ b/src/main/java/edu/handong/csee/histudy/impl/ReceivedFriendshipRequest.java
@@ -1,0 +1,11 @@
+package edu.handong.csee.histudy.impl;
+
+import edu.handong.csee.histudy.domain.Friendship;
+import edu.handong.csee.histudy.dto.FriendshipRequest;
+
+public class ReceivedFriendshipRequest extends FriendshipRequest {
+
+    public ReceivedFriendshipRequest(Friendship friendship) {
+        super(friendship.getSent(), friendship.getStatus());
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/impl/SentFriendshipRequest.java
+++ b/src/main/java/edu/handong/csee/histudy/impl/SentFriendshipRequest.java
@@ -1,0 +1,11 @@
+package edu.handong.csee.histudy.impl;
+
+import edu.handong.csee.histudy.domain.Friendship;
+import edu.handong.csee.histudy.dto.FriendshipRequest;
+
+public class SentFriendshipRequest extends FriendshipRequest {
+
+    public SentFriendshipRequest(Friendship friendship) {
+        super(friendship.getReceived(), friendship.getStatus());
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -1,0 +1,33 @@
+package edu.handong.csee.histudy.service;
+
+import edu.handong.csee.histudy.controller.form.BuddyForm;
+import edu.handong.csee.histudy.domain.Friendship;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public List<Friendship> sendRequest(User sender, BuddyForm form) {
+        userRepository
+                .findAllById(form.getBuddies())
+                .forEach(sender::add);
+
+        return sender.getSentRequests();
+    }
+
+    public User token2User(String accessToken) {
+        return userRepository
+                .findUserByAccessToken(accessToken)
+                .orElseThrow();
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -12,11 +12,11 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
 
-    @Transactional
     public List<Friendship> sendRequest(User sender, BuddyForm form) {
         userRepository
                 .findAllById(form.getBuddies())
@@ -25,9 +25,26 @@ public class UserService {
         return sender.getSentRequests();
     }
 
+    @Transactional(readOnly = true)
     public User token2User(String accessToken) {
         return userRepository
                 .findUserByAccessToken(accessToken)
                 .orElseThrow();
+    }
+
+    public void acceptRequest(User user, String sid) {
+        user.getReceivedRequests()
+                .stream()
+                .filter(friendship -> friendship.getSent().getSid().equals(sid))
+                .findAny()
+                .ifPresent(Friendship::accept);
+    }
+
+    public void declineRequest(User user, String sid) {
+        user.getReceivedRequests()
+                .stream()
+                .filter(friendship -> friendship.getSent().getSid().equals(sid))
+                .findAny()
+                .ifPresent(Friendship::decline);
     }
 }

--- a/src/test/java/edu/handong/csee/histudy/user/FriendshipTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/FriendshipTests.java
@@ -1,0 +1,117 @@
+package edu.handong.csee.histudy.user;
+
+import edu.handong.csee.histudy.domain.Friendship;
+import edu.handong.csee.histudy.domain.FriendshipStatus;
+import edu.handong.csee.histudy.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@Transactional
+public class FriendshipTests {
+
+    @DisplayName("내가 친구로 등록(요청)한 상대를 알 수 있다.")
+    @Test
+    public void FriendshipTests_17() {
+        // given
+        User userA = User.builder()
+                .name("userA")
+                .build();
+        User userB = User.builder()
+                .name("userB")
+                .build();
+
+        // when
+        userA.add(userB);
+        Friendship friendship = userA.getSentRequests()
+                .stream()
+                .findAny()
+                .orElseThrow();
+
+        // then
+        assertThat(friendship.getSent()).isEqualTo(userA);
+        assertThat(friendship.getReceived()).isEqualTo(userB);
+        assertThat(friendship.getStatus()).isEqualTo(FriendshipStatus.PENDING);
+    }
+
+    @DisplayName("나를 친구로 등록(요청)한 상대를 알 수 있다.")
+    @Test
+    public void FriendshipTests_42() {
+        // given
+        User userA = User.builder()
+                .name("userA")
+                .build();
+        User userB = User.builder()
+                .name("userB")
+                .build();
+
+        // when
+        userA.add(userB);
+        Friendship friendship = userB.getReceivedRequests()
+                .stream()
+                .findAny()
+                .orElseThrow();
+
+        // then
+        assertThat(friendship.getSent()).isEqualTo(userA);
+        assertThat(friendship.getReceived()).isEqualTo(userB);
+        assertThat(friendship.getStatus()).isEqualTo(FriendshipStatus.PENDING);
+    }
+
+    @DisplayName("등록(요청)한 상대에 대해 요청상태(대기, 수락, 거절) 등을 알 수 있다: 수락")
+    @Test
+    public void FriendshipTests_66() {
+        // given
+        User userA = User.builder()
+                .name("userA")
+                .build();
+        User userB = User.builder()
+                .name("userB")
+                .build();
+
+        // when
+        userA.add(userB);
+        userB.getReceivedRequests()
+                .stream()
+                .filter(friendship -> friendship.getSent().equals(userA))
+                .findAny()
+                .ifPresent((Friendship::accept));
+
+        Friendship friendship = userB.getReceivedRequests()
+                .stream()
+                .findAny()
+                .orElseThrow();
+
+        // then
+        assertThat(friendship.getSent()).isEqualTo(userA);
+        assertThat(friendship.getReceived()).isEqualTo(userB);
+        assertThat(friendship.getStatus()).isEqualTo(FriendshipStatus.ACCEPTED);
+    }
+
+    @DisplayName("등록(요청)한 상대에 대해 요청상태(대기, 수락, 거절) 등을 알 수 있다: 거절")
+    @Test
+    public void FriendshipTests_96() {
+        // given
+        User userA = User.builder()
+                .name("userA")
+                .build();
+        User userB = User.builder()
+                .name("userB")
+                .build();
+
+        // when
+        userA.add(userB);
+        userB.getReceivedRequests()
+                .stream()
+                .filter(friendship -> friendship.getSent().equals(userA))
+                .findAny()
+                .ifPresent(Friendship::decline);
+
+        // then
+        assertThat(userB.getReceivedRequests()).isEmpty();
+        assertThat(userA.getSentRequests()).isEmpty();
+    }
+}

--- a/src/test/java/edu/handong/csee/histudy/user/UserControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserControllerTests.java
@@ -1,0 +1,83 @@
+package edu.handong.csee.histudy.user;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.controller.UserController;
+import edu.handong.csee.histudy.controller.form.BuddyForm;
+import edu.handong.csee.histudy.domain.Friendship;
+import edu.handong.csee.histudy.domain.FriendshipStatus;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.dto.FriendshipDto;
+import edu.handong.csee.histudy.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+public class UserControllerTests {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @MockBean
+    UserService userService;
+
+    @DisplayName("스터디 친구를 등록한다")
+    @Test
+    public void UserControllerTests_13() throws Exception {
+        // given
+        User sender = User.builder()
+                .sid("21700123")
+                .name("sender")
+                .build();
+        User userA = User.builder()
+                .sid("21800123")
+                .name("userA")
+                .build();
+        User userB = User.builder()
+                .sid("21900123")
+                .name("userB")
+                .build();
+
+        BuddyForm form = new BuddyForm(userA.getSid(), userB.getSid());
+        String content = mapper.writeValueAsString(form);
+        when(userService.token2User(any()))
+                .thenReturn(sender);
+        when(userService.sendRequest(any(), any()))
+                .thenReturn(List.of(new Friendship(sender, userA), new Friendship(sender, userB)));
+
+        // when
+        MvcResult mvcResult = mockMvc
+                .perform(post("/api/user/buddy")
+                        .header(HttpHeaders.AUTHORIZATION, "access_token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        FriendshipDto res = mapper.readValue(mvcResult.getResponse().getContentAsString(),
+                FriendshipDto.class);
+
+        // then
+        assertEquals(2, res.getRequests().size());
+        assertEquals(FriendshipStatus.PENDING, res.getRequests().get(0).getStatus());
+    }
+}

--- a/src/test/java/edu/handong/csee/histudy/user/UserControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserControllerTests.java
@@ -65,7 +65,7 @@ public class UserControllerTests {
 
         // when
         MvcResult mvcResult = mockMvc
-                .perform(post("/api/user/buddy")
+                .perform(post("/api/users/me/friends")
                         .header(HttpHeaders.AUTHORIZATION, "access_token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(content))


### PR DESCRIPTION
- [x] 친구 요청 보내기
- [x] 친구 요청 수락/거절

수시 신청이 아닌 특정 시기에 일괄 신청을 하는 서비스 특성상, 친구 요청에 대한 응답을 기다리기보단 각자 신청을 하고 교차검증을 하는게 더 간편할 것으로도 보입니다. 

친구 상태를 유지함으로써 제공할 수 있는 것은 "신청시 입력한 친구는 신청하지 않아도 되는 점" 정도가 있을 것 같습니다.