### PR TITLE
#5: 로그인 및 회원가입 구현

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/config/JwtConfig.java
+++ b/src/main/java/edu/handong/csee/histudy/config/JwtConfig.java
@@ -1,21 +1,10 @@
 package edu.handong.csee.histudy.config;
 
 import edu.handong.csee.histudy.jwt.JwtProperties;
-import edu.handong.csee.histudy.jwt.JwtSecret;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableConfigurationProperties(JwtProperties.class)
 public class JwtConfig {
-
-    @Value("${custom.jwt.secret}")
-    private String secret;
-
-    @Bean
-    public JwtSecret jwtSecret() {
-        return new JwtSecret(secret);
-    }
 }

--- a/src/main/java/edu/handong/csee/histudy/config/WebConfig.java
+++ b/src/main/java/edu/handong/csee/histudy/config/WebConfig.java
@@ -16,6 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthenticationInterceptor(jwtService))
-                .excludePathPatterns("/api/auth/**", "/api/users");
+                .excludePathPatterns("/api/auth/**", "/api/users")
+                .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/config/WebConfig.java
+++ b/src/main/java/edu/handong/csee/histudy/config/WebConfig.java
@@ -16,6 +16,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthenticationInterceptor(jwtService))
-                .excludePathPatterns("/api/auth/**");
+                .excludePathPatterns("/api/auth/**", "/api/users");
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/controller/AuthController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AuthController.java
@@ -1,17 +1,18 @@
 package edu.handong.csee.histudy.controller;
 
+import edu.handong.csee.histudy.controller.form.TokenForm;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.jwt.GrantType;
 import edu.handong.csee.histudy.jwt.JwtPair;
+import edu.handong.csee.histudy.jwt.TokenInfo;
 import edu.handong.csee.histudy.service.JwtService;
 import edu.handong.csee.histudy.service.UserService;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
 
@@ -43,5 +44,25 @@ public class AuthController {
                 .body(UserDto.Login.builder()
                         .isRegistered(false)
                         .build());
+    }
+
+    @PostMapping("/token")
+    public ResponseEntity<TokenInfo> issueAccessToken(@RequestBody TokenForm tokenForm) {
+        Optional<String> refreshTokenOr = Optional.ofNullable(tokenForm.getRefreshToken());
+        Optional<Claims> claimsOr = jwtService.validate(refreshTokenOr);
+
+        if (refreshTokenOr.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .build();
+        } else if (claimsOr.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .build();
+        }
+        Claims claims = claimsOr.get();
+        String email = claims.getSubject();
+        String name = claims.get("name", String.class);
+        String accessToken = jwtService.issueToken(email, name, GrantType.ACCESS_TOKEN);
+
+        return ResponseEntity.ok(new TokenInfo(GrantType.ACCESS_TOKEN, accessToken));
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/controller/AuthController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AuthController.java
@@ -1,0 +1,47 @@
+package edu.handong.csee.histudy.controller;
+
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.jwt.JwtPair;
+import edu.handong.csee.histudy.service.JwtService;
+import edu.handong.csee.histudy.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+    private final JwtService jwtService;
+
+    @GetMapping("/login")
+    public ResponseEntity<UserDto.Login> login(@RequestParam String sub) {
+        Optional<User> userOr = userService.isPresent(sub);
+
+        if (userOr.isPresent()) {
+            User user = userOr.get();
+            JwtPair tokens = jwtService.issueToken(user.getEmail(), user.getName());
+
+            return ResponseEntity.ok(
+                    UserDto.Login.builder()
+                            .isRegistered(true)
+                            .tokenType("Bearer ")
+                            .tokens(tokens)
+                            .build());
+        }
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(UserDto.Login.builder()
+                        .isRegistered(false)
+                        .build());
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/controller/UserController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/UserController.java
@@ -1,15 +1,20 @@
 package edu.handong.csee.histudy.controller;
 
 import edu.handong.csee.histudy.controller.form.BuddyForm;
+import edu.handong.csee.histudy.controller.form.UserInfo;
 import edu.handong.csee.histudy.domain.Friendship;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.FriendshipDto;
 import edu.handong.csee.histudy.dto.FriendshipRequest;
+import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.impl.ReceivedFriendshipRequest;
 import edu.handong.csee.histudy.impl.SentFriendshipRequest;
+import edu.handong.csee.histudy.jwt.JwtPair;
+import edu.handong.csee.histudy.service.JwtService;
 import edu.handong.csee.histudy.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,6 +26,21 @@ import java.util.stream.Collectors;
 public class UserController {
 
     private final UserService userService;
+    private final JwtService jwtService;
+
+    @PostMapping
+    public ResponseEntity<UserDto.Login> createUser(@RequestBody UserInfo userInfo) {
+        if (userService.signUp(userInfo)) {
+            JwtPair tokens = jwtService.issueToken(userInfo.getEmail(), userInfo.getName());
+
+            return ResponseEntity.ok(UserDto.Login.builder()
+                    .isRegistered(true)
+                    .tokenType("Bearer ")
+                    .tokens(tokens)
+                    .build());
+        }
+        return ResponseEntity.badRequest().build();
+    }
 
     @PostMapping("/me/friends")
     public FriendshipDto sendFriendRequest(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,

--- a/src/main/java/edu/handong/csee/histudy/controller/form/TokenForm.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/form/TokenForm.java
@@ -1,0 +1,12 @@
+package edu.handong.csee.histudy.controller.form;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public class TokenForm {
+    private final String grantType;
+    private final String refreshToken;
+}

--- a/src/main/java/edu/handong/csee/histudy/controller/form/UserInfo.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/form/UserInfo.java
@@ -12,4 +12,5 @@ public class UserInfo {
     private String sub;
     private String name;
     private String email;
+    private String sid; // Student ID
 }

--- a/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
@@ -1,0 +1,16 @@
+package edu.handong.csee.histudy.dto;
+
+import edu.handong.csee.histudy.jwt.JwtPair;
+import lombok.Builder;
+import lombok.Getter;
+
+public class UserDto {
+
+    @Builder
+    @Getter
+    public static class Login {
+        private final Boolean isRegistered;
+        private final String tokenType;
+        private final JwtPair tokens;
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/jwt/JwtPair.java
+++ b/src/main/java/edu/handong/csee/histudy/jwt/JwtPair.java
@@ -1,0 +1,19 @@
+package edu.handong.csee.histudy.jwt;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JwtPair {
+    private String accessToken;
+    private String refreshToken;
+
+    public JwtPair(List<String> tokens) {
+        this.accessToken = tokens.get(0);
+        this.refreshToken = tokens.get(1);
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/jwt/JwtProperties.java
+++ b/src/main/java/edu/handong/csee/histudy/jwt/JwtProperties.java
@@ -3,18 +3,30 @@ package edu.handong.csee.histudy.jwt;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
 @ConfigurationProperties(prefix = "custom.jwt")
 public class JwtProperties {
 
+    private final SecretKey key;
     private final String issuer;
     private final String accessTokenExpiry;
     private final String refreshTokenExpiry;
 
     @ConstructorBinding
-    public JwtProperties(String issuer, String accessTokenExpiry, String refreshTokenExpiry) {
+    public JwtProperties(String secret, String issuer, String accessTokenExpiry, String refreshTokenExpiry) {
         this.issuer = issuer;
         this.accessTokenExpiry = accessTokenExpiry;
         this.refreshTokenExpiry = refreshTokenExpiry;
+
+        byte[] decoded = Base64.getDecoder().decode(secret);
+        this.key = new SecretKeySpec(decoded, "HmacSHA256");
+    }
+
+    public SecretKey getKey() {
+        return key;
     }
 
     public String getIssuer() {

--- a/src/main/java/edu/handong/csee/histudy/jwt/TokenInfo.java
+++ b/src/main/java/edu/handong/csee/histudy/jwt/TokenInfo.java
@@ -1,0 +1,12 @@
+package edu.handong.csee.histudy.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenInfo {
+    private final String tokenType = "Bearer ";
+    private final GrantType grantType;
+    private final String token;
+}

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -1,7 +1,9 @@
 package edu.handong.csee.histudy.service;
 
 import edu.handong.csee.histudy.controller.form.BuddyForm;
+import edu.handong.csee.histudy.controller.form.UserInfo;
 import edu.handong.csee.histudy.domain.Friendship;
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -46,5 +49,26 @@ public class UserService {
                 .filter(friendship -> friendship.getSent().getSid().equals(sid))
                 .findAny()
                 .ifPresent(Friendship::decline);
+    }
+
+    public boolean signUp(UserInfo userInfo) {
+        Optional<User> userOr = userRepository.findById(userInfo.getSub());
+
+        if (userOr.isEmpty()) {
+            User user = User.builder()
+                    .id(userInfo.getSub())
+                    .sid(userInfo.getSid())
+                    .email(userInfo.getEmail())
+                    .name(userInfo.getName())
+                    .role(Role.USER)
+                    .build();
+            userRepository.save(user);
+            return true;
+        }
+        return false;
+    }
+
+    public Optional<User> isPresent(String sub) {
+        return userRepository.findById(sub);
     }
 }

--- a/src/test/java/edu/handong/csee/histudy/auth/AuthControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/auth/AuthControllerTests.java
@@ -1,20 +1,25 @@
 package edu.handong.csee.histudy.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.controller.form.TokenForm;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.jwt.GrantType;
+import edu.handong.csee.histudy.jwt.TokenInfo;
 import edu.handong.csee.histudy.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -69,5 +74,59 @@ public class AuthControllerTests {
         assertNotNull(res);
         assertEquals("Bearer ", res.getTokenType());
         assertTrue(res.getIsRegistered());
+    }
+
+    @DisplayName("토큰 재발급: 유효하지 않은 Refresh token")
+    @Test
+    void AuthControllerTests_76() throws Exception {
+        // given
+        String invalidJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+                "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        TokenForm tokenForm = new TokenForm(GrantType.REFRESH_TOKEN.name(), invalidJwt);
+        String form = mapper.writeValueAsString(tokenForm);
+
+        // when
+        mvc
+                .perform(post("/api/auth/token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(form))
+                .andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+
+    @DisplayName("토큰 재발급: 페이로드가 없음")
+    @Test
+    void AuthControllerTests_86() throws Exception {
+        mvc
+                .perform(post("/api/auth/token"))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @DisplayName("토큰 재발급: 유효한 요청")
+    @Test
+    void AuthControllerTests_96() throws Exception {
+        // given
+        String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                "eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJzdWIiOiJ0ZXN0QGV4YW1wbGUuY29tIiwibmFtZSI6InVzZXIifQ." +
+                "ZB9yuKUvuufMfbXkzB647PoSCw-3rc2FA-PoHzKLYgM";
+        TokenForm tokenForm = new TokenForm(GrantType.REFRESH_TOKEN.name(), jwt);
+        String form = mapper.writeValueAsString(tokenForm);
+
+        // when
+        MvcResult mvcResult = mvc
+                .perform(post("/api/auth/token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(form))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        TokenInfo res = mapper.readValue(mvcResult.getResponse().getContentAsString(),
+                TokenInfo.class);
+
+        // then
+        assertEquals(GrantType.ACCESS_TOKEN, res.getGrantType());
     }
 }

--- a/src/test/java/edu/handong/csee/histudy/auth/AuthControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/auth/AuthControllerTests.java
@@ -1,0 +1,73 @@
+package edu.handong.csee.histudy.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+public class AuthControllerTests {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @DisplayName("유저 정보가 존재하지 않는 경우: 404 Not Found")
+    @Test
+    void AuthControllerTests_17() throws Exception {
+        mvc
+                .perform(get("/api/auth/login")
+                        .queryParam("sub", "1234"))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("유저 정보가 존재하는 경우: 200 OK with Tokens")
+    @Test
+    void AuthControllerTests_29() throws Exception {
+        // given
+        User user = User.builder()
+                .id("1234")
+                .email("test@example.com")
+                .name("username")
+                .build();
+        userRepository.save(user);
+
+        // when
+        MvcResult mvcResult = mvc
+                .perform(get("/api/auth/login")
+                        .queryParam("sub", "1234"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        UserDto.Login res = mapper.readValue(
+                mvcResult.getResponse().getContentAsString(),
+                UserDto.Login.class);
+
+        // then
+        assertNotNull(res);
+        assertEquals("Bearer ", res.getTokenType());
+        assertTrue(res.getIsRegistered());
+    }
+}


### PR DESCRIPTION
로그인/회원가입시 액세스 토큰과 리프레시 토큰을 발급하도록 했습니다.

액세스 토큰이 만료된 경우 리프레시 토큰으로 액세스 토큰을 재발급 받을 수 있는 로직도 추가했습니다.

이해를 돕기 위해 `auth` 서버를 분리했는데 실제로는 같은 서버이고 엔드포인트만 다릅니다.

<img src="https://github.com/Hisstudy-team05/histudy-be/assets/45687157/ae74cc03-4b92-4812-ae5f-eca8892d865a" width="50%" height="100%" />

resolved: #5
